### PR TITLE
Replace deprecated `thread::sleep_ms()`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,8 @@ fn main() {
             let frame_time = time::now() - now;
             let sleep_interval = time::Duration::milliseconds(1000 / fps_cap);
             if frame_time < sleep_interval {
-                thread::sleep_ms((sleep_interval - frame_time).num_milliseconds() as u32);
+            	let duration = std::time::Duration::from_millis((sleep_interval - frame_time).num_milliseconds() as u64);
+                thread::sleep(duration);
             }
         }
         window.gl_swap_window();


### PR DESCRIPTION
Replaced `thread::sleep_ms()` with `thread::sleep()`.
Gets rid of "deprecated item" warning.