### PR TITLE
Use absolute paths when including resources, fixes #53.

### DIFF
--- a/resources/build.rs
+++ b/resources/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::io::BufWriter;
 use std::io::Write;
 
@@ -15,23 +15,27 @@ fn main() {
     let mut file = BufWriter::new(fs::File::create(&dest.join("resources.rs")).unwrap());
     write!(file, "pub fn get_file(name: &str) -> Option<&'static [u8]> {{\n").unwrap();
     write!(file, "    match name {{\n").unwrap();
-    for entry in &out {
-    	let entry = entry.replace("\\", "/");
-    	let short = &entry;
-    	write!(file, "        {:?} => Some(include_bytes!(\"../{}\")),\n", short, entry).unwrap();
+    for path in &out {
+        let mut absolute_path = std::env::current_dir().unwrap();
+        absolute_path.push(path);
+
+        let absolute = absolute_path.to_str().unwrap().replace("\\", "/");
+        let relative = path.to_str().unwrap().replace("\\", "/");
+
+        write!(file, "        {:?} => Some(include_bytes!(\"{}\")),\n", relative, absolute).unwrap();
     }
     write!(file, "        _ => None\n    }}\n}}\n").unwrap();
 
 }
 
-fn build_map(out: &mut Vec<String>, path: &Path) {
+fn build_map(out: &mut Vec<PathBuf>, path: &Path) {
     let files = fs::read_dir(path).unwrap();
     for entry in files {
-    	let entry = entry.unwrap();
-    	if fs::metadata(entry.path()).unwrap().is_dir() {
-    		build_map(out, &entry.path());
-    	} else {
-    		out.push(entry.path().to_str().unwrap().to_owned());
-    	}
+        let entry = entry.unwrap();
+        if fs::metadata(entry.path()).unwrap().is_dir() {
+            build_map(out, &entry.path());
+        } else {
+            out.push(entry.path());
+        }
     }
 }


### PR DESCRIPTION
This fixes the build again.

Using absolute paths there isn't even as problematic as I thought at first. The resources.rs file will be regenerated every time the crate is built and the paths are only referenced at compile time for the include! macros. In fact it might even be the better solution if cargo changes its build directory structure in the future.

I wasn't able to run steven on my computer though, but I guess it's becaue I have some issues with my somewhat aged card. I don't expect any kind of maintainance with this I was just curious what the state of this client is - maybe I will work a bit on it in the next weeks.