### PR TITLE
Fix use of deprecated Rc:would_unwrap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@
 
 #![recursion_limit="300"]
 #![feature(const_fn)]
-#![feature(rc_would_unwrap)]
 
 extern crate sdl2;
 extern crate zip;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -80,7 +80,7 @@ macro_rules! define_elements {
             fn is_unused(&self) -> bool {
                 match *self {
                     $(
-                        Element::$name(ref inner) => Rc::would_unwrap(inner),
+                        Element::$name(ref inner) => Rc::strong_count(inner) == 1,
                     )*
                 }
             }


### PR DESCRIPTION
Compiling with rustc 1.19.0-nightly (e17a1227a 2017-05-12) fails due to the use of Rc::would_unwrap, https://doc.rust-lang.org/std/rc/struct.Rc.html says this is deprecated in favor of strong_count, error:

```
error: no associated item named `would_unwrap` found for type `std::rc::Rc<_>` in the current scope
   --> src/ui/mod.rs:83:54
    |
83  |                           Element::$name(ref inner) => Rc::would_unwrap(inner),
    |                                                        ^^^^^^^^^^^^^^^^
...
```

I changed it to Rc:strong_count(inner) == 1, based on the comment in https://github.com/rust-lang/rust/issues/27718#issuecomment-130784562. This fixes the error although I'm not 100% sure it is correct, unable to test since linkage fails to a different reason (https://github.com/Thinkofname/steven/issues/67) **update**: able to run steven now, but it panics, I am not sure if it is related (brand new to rust): https://github.com/Thinkofname/steven/issues/69